### PR TITLE
Change "Organisation" to "Organization" in English section

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-### Welcome to the Open Disaster Risk Reduction Organisation on GitHub
+### Welcome to the Open Disaster Risk Reduction Organization on GitHub
 
 Looking for data? Head over to [Downloads](https://opendrr.github.io/downloads/en/)
 


### PR DESCRIPTION
Seems "organization" is the Canadian spelling, e.g. https://www.canada.ca/en/public-service-commission/services/public-service-hiring-guides/information-staffing-obligations/reference-list-organizations.html

Many thanks!